### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/visual_version_control/app.py
+++ b/visual_version_control/app.py
@@ -1,8 +1,10 @@
 from flask import Flask, render_template, jsonify, request
 from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime
+import logging
 
 app = Flask(__name__)
+logging.basicConfig(level=logging.ERROR, format='%(asctime)s %(levelname)s %(message)s')
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///versions.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
@@ -49,7 +51,8 @@ def manage_versions():
         })
     
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        logging.error("An error occurred: %s", str(e))
+        return jsonify({"error": "An internal error has occurred!"}), 500
 
 @app.route('/api/versions/<int:id>', methods=['DELETE'])
 def delete_version(id):
@@ -59,7 +62,8 @@ def delete_version(id):
         db.session.commit()
         return jsonify({"message": "Version deleted"}), 204
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        logging.error("An error occurred: %s", str(e))
+        return jsonify({"error": "An internal error has occurred!"}), 500
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
Potential fix for [https://github.com/RedPillCoder/Visual-Version-Control/security/code-scanning/2](https://github.com/RedPillCoder/Visual-Version-Control/security/code-scanning/2)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Configure the logging settings to log error messages to a file or console.
3. Modify the exception handling blocks to log the exception details and return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
